### PR TITLE
feat(constants): add Swift project files to gitignore pattern

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,10 @@ export const JUNK_DIRS = [
     '.firebase',
     '.tern-port',
     '.turbo',
+    // https://github.com/github/gitignore/blob/main/Swift.gitignore
+    '.build',
+    'build',
+    'Carthage',
 ]
 
 export const JUNK_FILES = [


### PR DESCRIPTION
- Added .build directory to ignored patterns
- Added build directory to ignored patterns
- Added Carthage directory to ignored patterns
- Included Swift gitignore references from GitHub repository


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the list of ignored junk directories to include `.build`, `build`, and `Carthage`, reducing unnecessary noise from generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->